### PR TITLE
bot_promptを設定できるように変更

### DIFF
--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -5,6 +5,7 @@ module OmniAuth
   module Strategies
     class Line < OmniAuth::Strategies::OAuth2
       option :name, 'line'
+      option :authorize_options, %i[scope state bot_prompt]
       option :scope, 'profile openid email'
 
       option :client_options, {
@@ -12,6 +13,8 @@ module OmniAuth
         authorize_url: '/oauth2/v2.1/authorize',
         token_url: '/oauth2/v2.1/token'
       }
+
+      option :bot_prompt, 'normal'
 
       # host changed
       def callback_phase
@@ -41,11 +44,11 @@ module OmniAuth
       end
 
       private
-        def get_raw_info
-          # https://developers.line.biz/ja/reference/social-api/#verify-id-token
-          res = access_token.post("oauth2/v2.1/verify", {body: {id_token: access_token.params["id_token"], client_id: options[:client_id]}})
-          JSON.load(res.body)
-        end
+      def get_raw_info
+        # https://developers.line.biz/ja/reference/social-api/#verify-id-token
+        res = access_token.post("oauth2/v2.1/verify", {body: {id_token: access_token.params["id_token"], client_id: options[:client_id]}})
+        JSON.load(res.body)
+      end
     end
   end
 end


### PR DESCRIPTION
lineの登録の際にbotを友達登録にするかどうかを表示できるように変更
urlのクエリパラメータにbot_promptを追加されるようにする
https://developers.line.biz/ja/docs/line-login/link-a-bot/#redirect-user

authorize_optionsにbot_promptを追加するようにオーバライド
https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L27

📝
ここでurlを整形している
https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L58-L60

authorize_paramsに詰めているところ
https://github.com/omniauth/omniauth-oauth2/blob/8438b89b712e03337932a0d95096258c892ea0f3/lib/omniauth/strategies/oauth2.rb#L71

sendメソッドで許可するパラメータを探していた(sendメソッド苦手・・・)
https://github.com/omniauth/omniauth-oauth2/blob/8438b89b712e03337932a0d95096258c892ea0f3/lib/omniauth/strategies/oauth2.rb#L135-L145